### PR TITLE
Bug chat bubble

### DIFF
--- a/ChatWidget.cpp
+++ b/ChatWidget.cpp
@@ -199,14 +199,15 @@ void ChatWidget::initSignalsAndSlots()
     connect(ui->pushButtonSend, &QPushButton::clicked, this, &ChatWidget::slotButtonToSendMessage);
     connect(ui->pushButtonSendGroup, &QPushButton::clicked, this, &ChatWidget::slotButtonToSendMessageGroup);
     qInfo() << "connect pushButtonSend::clicked to ChatWidget::slotButtonToSendMessage";
-    connect(ui->pushButtonCloseGroup,&QPushButton::clicked,this,[this](){
+    connect(ui->pushButtonCloseGroup, &QPushButton::clicked, this, [this]()
+    {
         QPixmap head(":/test/res/test/head1.jpg");
         QString content = zsj::HtmlUtil::GetHtmlBodyContent(ui->textEditMessageInputGroup->toHtml());
         QMap<InputMessageType, QStringList> messageMap = parser.parserMessage(content);
         for(auto iter = messageMap.begin(); iter != messageMap.end(); ++iter)
         {
             addMessageItem(ui->listWidgetMessageListGroup, head,
-                           iter.key(), iter.value().at(0),false);
+                           iter.key(), iter.value().at(0), false);
         }
         ui->textEditMessageInputGroup->clear();
     });
@@ -420,13 +421,13 @@ void ChatWidget::addMessageItem(QListWidget *listWidget, QPixmap &head,
             if(parser.contentJudgeEmpty(message)){ \
                 data->setHasEmoji(true); \
                 widget = new ChatMessageItem##name(data, item, listWidget); \
-                break; \
             } \
+            break; \
         case InputMessageType::PLAIN_TEXT: \
             if(parser.contentJudgeEmpty(message)){ \
                 widget = new ChatMessageItem##name(data, item, listWidget); \
-                break; \
             }\
+            break; \
     }
 
     QListWidgetItem *item = new QListWidgetItem(listWidget);
@@ -743,9 +744,7 @@ QMap<ChatWidget::InputMessageType, QStringList> ChatWidget::MessageParser::parse
 {
     //去掉第一个QTextedit自带的换行\n
     int begin = originmessage.indexOf("\n");
-    qDebug() << begin;
     originmessage = originmessage.remove(begin, 1);
-    qDebug() << originmessage;
 
     QMap<ChatWidget::InputMessageType, QStringList> messageMap;
     bool hasEmoji = false;

--- a/ChatWidget.h
+++ b/ChatWidget.h
@@ -6,6 +6,7 @@
 #include <QListWidget>
 
 #include <QRect>
+#include <QStringList>
 
 #include "main/Frameless.h"
 #include "main/Data.h"
@@ -19,6 +20,12 @@ class ChatWidget;
 class ChatWidget : public QWidget
 {
     Q_OBJECT
+public:
+    enum class InputMessageType{
+        PLAIN_TEXT = 0, // 只含文本
+        IMAGE,          // 只含文件
+        EMOJI_TEXT      // 包含表情和文本
+    };
 public:
     explicit ChatWidget(QWidget *parent = nullptr);
     ~ChatWidget();
@@ -37,6 +44,30 @@ protected:
 
 
     bool event(QEvent *event);
+
+private:
+
+
+    /**
+     * @brief 消息解析器
+     */
+    class MessageParser{
+    public:
+        /**
+         * @brief 解析消息
+         * @param originmessage 原生消息
+         * @return
+         */
+        QMap<InputMessageType,QStringList> parserMessage(QString originmessage);
+
+
+        /**
+         * @brief 判定当前消息内容是否为空
+         * @param content 内容
+         * @return
+         */
+        bool contentJudgeEmpty(const QString & content);
+    };
 
 private:
 
@@ -77,7 +108,20 @@ private:
     /// @param[in] listWidget 需要添加item的QListWidget
     /// @param[in] head 头像
     /// @param[in] message 聊天消息
+    /// @note 废弃，参数过少，使用下面一个。后续删除
     void addMessageItem(QListWidget * listWidget,QPixmap & head,const QString & message,bool isSelf = true);
+
+
+    /**
+     * @brief 添加信息item
+     * @param listWidget 需要添加item的QListWidget
+     * @param head 头像
+     * @param inputType 聊天信息的分类
+     * @param message 聊天消息
+     * @param isSelf 是否是自己所发信息
+     */
+    void addMessageItem(QListWidget * listWidget,QPixmap & head,InputMessageType inputType,
+                        const QString & message,bool isSelf = true);
 
 
     /// @brief 切换聊天对象
@@ -112,6 +156,10 @@ private:
 
     /// 常用表情窗口
     EmojiHotWidget * emojiHotWidget = nullptr;
+
+
+    /// 解析需要发送的消息
+    MessageParser parser;
 
 public slots:
 

--- a/ChatWidget.ui
+++ b/ChatWidget.ui
@@ -410,7 +410,7 @@
           <item row="1" column="0">
            <widget class="QStackedWidget" name="stackedWidgetMain">
             <property name="currentIndex">
-             <number>1</number>
+             <number>0</number>
             </property>
             <widget class="QWidget" name="pageUser">
              <layout class="QGridLayout" name="gridLayout_16">
@@ -970,7 +970,7 @@
                             <widget class="MyTextEdit" name="textEditMessageInput">
                              <property name="font">
                               <font>
-                               <pointsize>9</pointsize>
+                               <pointsize>16</pointsize>
                               </font>
                              </property>
                              <property name="tabChangesFocus">
@@ -1715,6 +1715,11 @@
                                   </property>
                                   <item row="0" column="0">
                                    <widget class="MyTextEdit" name="textEditMessageInputGroup">
+                                    <property name="font">
+                                     <font>
+                                      <pointsize>16</pointsize>
+                                     </font>
+                                    </property>
                                     <property name="tabChangesFocus">
                                      <bool>true</bool>
                                     </property>

--- a/MainWidget.cpp
+++ b/MainWidget.cpp
@@ -242,27 +242,27 @@ void MainWidget::initMessageList()
 void MainWidget::initMenus()
 {
     userMenu = new QMenu();
-    zsj::StaticIniator::Instatcne()->initFirendMenu(userMenu, this);
+    zsj::StaticIniator::Instance()->initFirendMenu(userMenu, this);
 
     sectionMenu = new QMenu();
-    zsj::StaticIniator::Instatcne()->initFirendSectionMenu(sectionMenu, this);
+    zsj::StaticIniator::Instance()->initFirendSectionMenu(sectionMenu, this);
 
     groupMenu = new QMenu();
-    zsj::StaticIniator::Instatcne()->initGroupMenu(groupMenu, this);
+    zsj::StaticIniator::Instance()->initGroupMenu(groupMenu, this);
 
     groupSectionMenu = new QMenu();
-    zsj::StaticIniator::Instatcne()->initGroupSectionMenu(groupSectionMenu, this);
+    zsj::StaticIniator::Instance()->initGroupSectionMenu(groupSectionMenu, this);
 
     moveSubMenuFriend = new QMenu();
     moveSubMenuFriend->setObjectName("moveSubMenuFriend");
     connect(moveSubMenuFriend, &QMenu::triggered, this, &MainWidget::moveItem);
-    zsj::StaticIniator::Instatcne()->initMenusStyle(moveSubMenuFriend);
+    zsj::StaticIniator::Instance()->initMenusStyle(moveSubMenuFriend);
 
 
     moveSubMenuGroup = new QMenu();
     moveSubMenuGroup->setObjectName("moveSubMenuGroup");
     connect(moveSubMenuGroup, &QMenu::triggered, this, &MainWidget::moveItem);
-    zsj::StaticIniator::Instatcne()->initMenusStyle(moveSubMenuGroup);
+    zsj::StaticIniator::Instance()->initMenusStyle(moveSubMenuGroup);
 
 
 }

--- a/MySelfQQ_v2.pro
+++ b/MySelfQQ_v2.pro
@@ -57,7 +57,10 @@ SOURCES += main.cpp \
     feature_widgets/EmojiTableWidget.cpp \
     main/EmojiInfo.cpp \
     main/StringUserData.cpp \
-    feature_widgets/EmojiHotWidget.cpp
+    feature_widgets/EmojiHotWidget.cpp \
+    item_widgets/ChatMessageImageItemSelf.cpp \
+    main/CurrentWindow.cpp \
+    item_widgets/ChatMessageImageItemObject.cpp
 
 
 
@@ -107,7 +110,10 @@ HEADERS  += ChatWidget.h \
     feature_widgets/EmojiTableWidget.h \
     main/EmojiInfo.h \
     main/StringUserData.h \
-    feature_widgets/EmojiHotWidget.h
+    feature_widgets/EmojiHotWidget.h \
+    item_widgets/ChatMessageImageItemSelf.h \
+    main/CurrentWindow.h \
+    item_widgets/ChatMessageImageItemObject.h
 
 
 FORMS    +=     LoginWidget.ui \
@@ -124,7 +130,9 @@ FORMS    +=     LoginWidget.ui \
     item_widgets/ChatMessageItemSelf.ui \
     item_widgets/MessageItemWidget.ui \
     feature_widgets/EmojiWidget.ui \
-    feature_widgets/EmojiHotWidget.ui
+    feature_widgets/EmojiHotWidget.ui \
+    item_widgets/ChatMessageImageItemSelf.ui \
+    item_widgets/ChatMessageImageItemObject.ui
 
 
 

--- a/MySelfQQ_v2.pro.user
+++ b/MySelfQQ_v2.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.8.0, 2021-02-26T18:05:08. -->
+<!-- Written by QtCreator 4.8.0, 2021-03-03T08:46:29. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -317,7 +317,7 @@
     <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
     <value type="QString" key="RunConfiguration.WorkingDirectory"></value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">D:/QT/QtCode/MySelfQQ_v2/build/build-MySelfQQ_v2-Desktop_Qt_5_12_0_MinGW_64_bit-Debug</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default"></value>
    </valuemap>
    <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
   </valuemap>

--- a/css/chat.css
+++ b/css/chat.css
@@ -93,8 +93,7 @@ QToolButton,QToolButton:!checked,QToolButton:!selected{
 #toolButtonScreenShot:checked,
 #toolButtonWindowShake:checked{
 	background: rgba(0,0,0,0.1);
-	border:1px solid red;
-	margin-left:0px;
+	margin-left: 0px;
 	margin-top: 0px;
 }
 

--- a/css/emoji.css
+++ b/css/emoji.css
@@ -90,6 +90,8 @@ QTableWidget::item:hover{
 }
 
 
+
+/* QScrollBar */
 QScrollBar:vertical{
     background: transparent;
     width:8px;

--- a/customer_widgets/MyTextEdit.cpp
+++ b/customer_widgets/MyTextEdit.cpp
@@ -72,9 +72,7 @@ bool MyTextEdit::eventFilter(QObject *, QEvent *event)
                 if(isOk)
                 {
                     QSize pasteSize = zsj::Util::ScaledImageSize(pix.size());
-                    QString imgUrl = QString("<img src='%1' width=%2 height=%3 ></img>")
-                                     .arg(imagePath).arg(pasteSize.width()).arg(pasteSize.height());
-                    qDebug() << imgUrl;
+                    QString imgUrl = zsj::Util::PackageImageHtml(imagePath,pasteSize.width(),pasteSize.height());
                     this->insertHtml(imgUrl);
                 }
                 else
@@ -91,6 +89,7 @@ bool MyTextEdit::eventFilter(QObject *, QEvent *event)
         }
     }
     return false;
+
 }
 
 
@@ -98,18 +97,27 @@ void MyTextEdit::emitSigToSendMessage(bool EnterKeyFlag)
 {
     if(EnterKeyFlag)
     {
-        QString msg = this->toPlainText();
-        if(msg.isEmpty())
+        QString content = getContents();
+        if(content.isEmpty())
         {
             emit sigMsgEmpty();
             return;
         }
-        emit sigKeyToSendMsg(msg);
+        emit sigKeyToSendMsg(content);
     }
     else
     {
         // 如果当前按键并不是发送消息的按钮，则在文本框添加一个 \n
         this->insertPlainText("\n");
     }
+}
+
+QString MyTextEdit::getContents()
+{
+    QString html = toHtml();
+    int begin = html.indexOf("<body");
+    int bodyEnd = html.indexOf("</body>",begin);
+    QString content = html.mid(begin,bodyEnd-begin+7);
+    return content;
 }
 

--- a/customer_widgets/MyTextEdit.h
+++ b/customer_widgets/MyTextEdit.h
@@ -25,9 +25,20 @@ private:
     /// @brief 发送信号到父组件，进行发送消息
     void emitSigToSendMessage(bool EnterKeyFlag = true);
 
+
+    /**
+     * @brief 所有内容
+     * @return 返回HTML的body标签里面的数据
+     */
+    QString getContents();
+
 private:
     /// @brief 是否回车发送消息，默认为回车（Enter）发送，可以改为（Enter+Ctrl）发送
     bool isEnterSendMsg = true;
+
+
+    /// 是否还有图片或者emoji
+    bool hasImage = false;
 signals:
     /// @brief 按键发送消息
     void sigKeyToSendMsg(const QString & message);

--- a/item_widgets/ChatMessageImageItemObject.cpp
+++ b/item_widgets/ChatMessageImageItemObject.cpp
@@ -1,0 +1,137 @@
+#include "ChatMessageImageItemObject.h"
+#include "ui_ChatMessageImageItemObject.h"
+
+#include "main/ChatBubble.h"
+#include "utils/Util.h"
+#include "main/CurrentWindow.h"
+
+ChatMessageImageItemObject::ChatMessageImageItemObject(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::ChatMessageImageItemObject)
+{
+    ui->setupUi(this);
+    initResourceAndForm();
+}
+
+ChatMessageImageItemObject::ChatMessageImageItemObject(zsj::ChatMessageData::ptr data,
+        QListWidgetItem *item,
+        QWidget *parent):
+    QWidget(parent),
+    ui(new Ui::ChatMessageImageItemObject),
+    chatMessageData(data),
+    item(item)
+{
+    ui->setupUi(this);
+    initResourceAndForm();
+}
+
+ChatMessageImageItemObject::~ChatMessageImageItemObject()
+{
+    delete ui;
+}
+
+void ChatMessageImageItemObject::initResourceAndForm()
+{
+    QPixmap ori = chatMessageData->getHead();
+    QPixmap localHead = zsj::adjustToHead(ori, 32);
+    ui->labelHead->setPixmap(localHead);
+
+
+    QString path = seprateImageSrc(chatMessageData->getImagePath());
+    image = QPixmap(path);
+
+    int fontSize = zsj::ChatBubble::Instance()->getBubbleFontSize();
+
+    this->setStyleSheet(QString("#labelHead{border-radius:16px;border:none;}"
+                                "#labelMessage{font-size:%1px;}"
+                                "#widget{border-radius:5px;border:1px solid green;}").arg(fontSize)
+                       );
+}
+
+void ChatMessageImageItemObject::adjustWidgetsPosition()
+{
+    QSize size = calculateMessageWidgetSize();
+    int padding = zsj::ChatBubble::Instance()->getBubblePadding();
+    ui->widget->setGeometry(QRect(50, 9, size.width() + 2 * padding, size.height() + 2 * padding));
+}
+
+QSize ChatMessageImageItemObject::calculateMessageWidgetSize()
+{
+    QRect windowGeometry = zsj::CurrentWindow::Instance()->getWindowGeometry();
+    QSize size = currentEnableImageSize(windowGeometry.size()) * 0.8;
+    return size;
+}
+
+QSize ChatMessageImageItemObject::getWidgetSize()
+{
+    int padding = zsj::ChatBubble::Instance()->getBubblePadding();
+    return QSize(ui->labelMessage->width() + 18 + 2 * padding,
+                 ui->labelMessage->height() + 18 + 2 * padding);
+}
+
+void ChatMessageImageItemObject::adjustImage()
+{
+    QSize size = calculateMessageWidgetSize();
+    QPixmap tempPix = zsj::scaledPixmap(image, size.width(), size.height());
+    ui->labelMessage->setPixmap(tempPix);
+}
+
+void ChatMessageImageItemObject::resizeEvent(QResizeEvent *event)
+{
+    adjustWidgetsPosition();
+    item->setSizeHint(getWidgetSize());
+    adjustImage();
+    QWidget::resizeEvent(event);
+}
+
+
+
+QSize ChatMessageImageItemObject::currentEnableImageSize(QSize windowSize)
+{
+    QPixmap pix(chatMessageData->getImagePath());
+    if(!pix.isNull())
+    {
+        int width = windowSize.width() / 2;
+        int height = windowSize.height() / 2;
+        if(pix.width() <= width && pix.height() <= height)
+        {
+            return QSize(width, height);
+        }
+        else if(pix.width() > width && pix.height() < height)
+        {
+            height = (width * 1.0 / pix.width()) * pix.height();
+        }
+        else if(pix.width() <= width && pix.height() > height)
+        {
+            width = (height * 1.0 / pix.height()) * pix.width();
+        }
+        else if(pix.width() > width && pix.height() > height)
+        {
+            float heightDivisor = height * 1.0 / pix.height();
+            float widthDivisor = width * 1.0 / pix.width();
+            float minDivisor = heightDivisor > widthDivisor ?
+                               widthDivisor : heightDivisor;
+            width = pix.width() * minDivisor;
+            height = pix.height() * minDivisor;
+        }
+        return QSize(width, height);
+    }
+    else{
+        qCritical() << chatMessageData->getImagePath() << " is null!";
+        return QSize();
+    }
+}
+
+QString ChatMessageImageItemObject::seprateImageSrc(const QString &imgTag)
+{
+    if(imgTag.contains("<img")){
+        int begin = imgTag.indexOf("src=\"");
+        int end = imgTag.indexOf("\"",begin+6);
+        QString path = imgTag.mid(begin + 5,end-begin - 5);
+        chatMessageData->setImagePath(path);
+        return path;
+    }
+    else{
+        return imgTag;
+    }
+}

--- a/item_widgets/ChatMessageImageItemObject.h
+++ b/item_widgets/ChatMessageImageItemObject.h
@@ -1,0 +1,73 @@
+/**
+  * @file ChatMessageImageItemObject.h
+  * @brief 消息列表中的消息类型。纯图片类型，用于显示图片
+  * @author zsj
+  * @date 2021年3月2日09:22:59
+  * @note 只用于显示图片。后续可以改进
+  */
+#ifndef CHATMESSAGEIMAGEITEMOBJECT_H
+#define CHATMESSAGEIMAGEITEMOBJECT_H
+
+#include <QWidget>
+#include <QString>
+#include <QListWidget>
+
+#include "item_widgets/ChatMessageItem.h"
+#include "main/ChatMessageData.h"
+
+namespace Ui {
+class ChatMessageImageItemObject;
+}
+
+class ChatMessageImageItemObject : public QWidget,public zsj::ChatMessageItem
+{
+    Q_OBJECT
+
+public:
+    explicit ChatMessageImageItemObject(QWidget *parent = nullptr);
+    ChatMessageImageItemObject(zsj::ChatMessageData::ptr data,QListWidgetItem * item,
+                               QWidget * parent = nullptr);
+    ~ChatMessageImageItemObject();
+
+    void adjustWidgetsPosition() override;
+    QSize calculateMessageWidgetSize() override;
+    QSize getWidgetSize()override;
+
+    /**
+     * @brief 每一次item变化后就需要重新贴图
+     */
+    void adjustImage();
+protected:
+    void resizeEvent(QResizeEvent *event);
+
+private:
+
+    void initResourceAndForm();
+
+    /**
+     * @brief 获取当前可显示的图片大小
+     * @param windowSize 当前窗口大小
+     * @return
+     */
+    QSize currentEnableImageSize(QSize windowSize);
+
+    /**
+     * @brief 将img标签中的src属性的值取出来
+     * @param imgTag 形如<img src="src" />
+     * @return
+     */
+    QString seprateImageSrc(const QString & imgTag);
+private:
+    Ui::ChatMessageImageItemObject *ui;
+
+    QListWidgetItem * item;
+
+    /// 聊天对象的数据
+    zsj::ChatMessageData::ptr chatMessageData;
+
+
+    /// 显示的图片呢
+    QPixmap image;
+};
+
+#endif // CHATMESSAGEIMAGEITEMOBJECT_H

--- a/item_widgets/ChatMessageImageItemObject.h
+++ b/item_widgets/ChatMessageImageItemObject.h
@@ -1,6 +1,6 @@
 /**
   * @file ChatMessageImageItemObject.h
-  * @brief 消息列表中的消息类型。纯图片类型，用于显示图片
+  * @brief 消息列表中的消息类型。纯图片类型，用于显示图片。显示在左边
   * @author zsj
   * @date 2021年3月2日09:22:59
   * @note 只用于显示图片。后续可以改进

--- a/item_widgets/ChatMessageImageItemObject.ui
+++ b/item_widgets/ChatMessageImageItemObject.ui
@@ -1,20 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ChatMessageItemSelf</class>
- <widget class="QWidget" name="ChatMessageItemSelf">
+ <class>ChatMessageImageItemObject</class>
+ <widget class="QWidget" name="ChatMessageImageItemObject">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>60</height>
+    <width>398</width>
+    <height>78</height>
    </rect>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>0</width>
-    <height>60</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
@@ -22,7 +16,7 @@
   <widget class="QWidget" name="widget" native="true">
    <property name="geometry">
     <rect>
-     <x>80</x>
+     <x>90</x>
      <y>10</y>
      <width>72</width>
      <height>30</height>
@@ -75,7 +69,7 @@
   <widget class="QLabel" name="labelHead">
    <property name="geometry">
     <rect>
-     <x>20</x>
+     <x>10</x>
      <y>10</y>
      <width>32</width>
      <height>32</height>

--- a/item_widgets/ChatMessageImageItemSelf.cpp
+++ b/item_widgets/ChatMessageImageItemSelf.cpp
@@ -1,0 +1,141 @@
+#include "ChatMessageImageItemSelf.h"
+#include "ui_ChatMessageImageItemSelf.h"
+
+#include "main/ChatBubble.h"
+#include "utils/Util.h"
+#include "main/CurrentWindow.h"
+
+#include <QSize>
+
+ChatMessageImageItemSelf::ChatMessageImageItemSelf(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::ChatMessageImageItemSelf)
+{
+    ui->setupUi(this);
+    initResourceAndForm();
+}
+
+ChatMessageImageItemSelf::ChatMessageImageItemSelf(zsj::ChatMessageData::ptr data,
+        QListWidgetItem *item,
+        QWidget *parent):
+    QWidget(parent),
+    ui(new Ui::ChatMessageImageItemSelf),
+    chatMessageData(data),
+    item(item)
+{
+    ui->setupUi(this);
+    initResourceAndForm();
+}
+
+ChatMessageImageItemSelf::~ChatMessageImageItemSelf()
+{
+    delete ui;
+}
+
+void ChatMessageImageItemSelf::initResourceAndForm()
+{
+    QPixmap ori = chatMessageData->getHead();
+    QPixmap localHead = zsj::adjustToHead(ori, 32);
+    ui->labelHead->setPixmap(localHead);
+
+    QString path = seprateImageSrc(chatMessageData->getImagePath());
+    image = QPixmap(path);
+
+    int fontSize = zsj::ChatBubble::Instance()->getBubbleFontSize();
+
+    this->setStyleSheet(QString("#labelHead{border-radius:16px;border:none;}"
+                                "#labelMessage{font-size:%1px;}"
+                                "#widget{border-radius:5px;border:1px solid green;}").arg(fontSize)
+                       );
+}
+
+void ChatMessageImageItemSelf::adjustWidgetsPosition()
+{
+    QSize size = calculateMessageWidgetSize();
+    int padding = zsj::ChatBubble::Instance()->getBubblePadding();
+    ui->labelHead->setGeometry(this->width() - 41, 9, ui->labelHead->width(), ui->labelHead->height());
+    ui->widget->setGeometry(QRect(this->width() - size.width() - 2 * padding - 50, 9, size.width() + 2 * padding, size.height() + 2 * padding));
+}
+
+QSize ChatMessageImageItemSelf::calculateMessageWidgetSize()
+{
+    QRect windowGeometry = zsj::CurrentWindow::Instance()->getWindowGeometry();
+    QSize size = currentEnableImageSize(windowGeometry.size()) * 0.8;
+    return size;
+}
+
+QSize ChatMessageImageItemSelf::getWidgetSize()
+{
+    int padding = zsj::ChatBubble::Instance()->getBubblePadding();
+    return QSize(ui->labelMessage->width() + 18 + 2 * padding,
+                 ui->labelMessage->height() + 18 + 2 * padding);
+}
+
+void ChatMessageImageItemSelf::adjustImage()
+{
+    QSize size = calculateMessageWidgetSize();
+    QPixmap tempPix = zsj::scaledPixmap(image, size.width(), size.height());
+    ui->labelMessage->setPixmap(tempPix);
+}
+
+void ChatMessageImageItemSelf::resizeEvent(QResizeEvent *event)
+{
+    adjustWidgetsPosition();
+    item->setSizeHint(getWidgetSize());
+    adjustImage();
+    QWidget::resizeEvent(event);
+}
+
+
+
+QSize ChatMessageImageItemSelf::currentEnableImageSize(QSize windowSize)
+{
+    QPixmap pix = image;
+    if(!pix.isNull())
+    {
+        int width = windowSize.width() / 2;
+        int height = windowSize.height() / 2;
+        if(pix.width() <= width && pix.height() <= height)
+        {
+            return QSize(width, height);
+        }
+        else if(pix.width() > width && pix.height() < height)
+        {
+            height = (width * 1.0 / pix.width()) * pix.height();
+        }
+        else if(pix.width() <= width && pix.height() > height)
+        {
+            width = (height * 1.0 / pix.height()) * pix.width();
+        }
+        else if(pix.width() > width && pix.height() > height)
+        {
+            float heightDivisor = height * 1.0 / pix.height();
+            float widthDivisor = width * 1.0 / pix.width();
+            float minDivisor = heightDivisor > widthDivisor ?
+                               widthDivisor : heightDivisor;
+            width = pix.width() * minDivisor;
+            height = pix.height() * minDivisor;
+        }
+        return QSize(width, height);
+    }
+    else
+    {
+        qCritical() << chatMessageData->getImagePath() << " is null!";
+        return QSize();
+    }
+}
+
+QString ChatMessageImageItemSelf::seprateImageSrc(const QString &imgTag)
+{
+    if(imgTag.contains("<img")){
+        int begin = imgTag.indexOf("src=\"");
+        int end = imgTag.indexOf("\"",begin+6);
+        QString path = imgTag.mid(begin + 5,end-begin - 5);
+        chatMessageData->setImagePath(path);
+        return path;
+    }
+    else{
+        return imgTag;
+    }
+
+}

--- a/item_widgets/ChatMessageImageItemSelf.cpp
+++ b/item_widgets/ChatMessageImageItemSelf.cpp
@@ -9,7 +9,9 @@
 
 ChatMessageImageItemSelf::ChatMessageImageItemSelf(QWidget *parent) :
     QWidget(parent),
-    ui(new Ui::ChatMessageImageItemSelf)
+    ui(new Ui::ChatMessageImageItemSelf),
+    item(nullptr),
+    chatMessageData(nullptr)
 {
     ui->setupUi(this);
     initResourceAndForm();
@@ -20,8 +22,9 @@ ChatMessageImageItemSelf::ChatMessageImageItemSelf(zsj::ChatMessageData::ptr dat
         QWidget *parent):
     QWidget(parent),
     ui(new Ui::ChatMessageImageItemSelf),
-    chatMessageData(data),
-    item(item)
+    item(item),
+    chatMessageData(data)
+
 {
     ui->setupUi(this);
     initResourceAndForm();
@@ -127,14 +130,16 @@ QSize ChatMessageImageItemSelf::currentEnableImageSize(QSize windowSize)
 
 QString ChatMessageImageItemSelf::seprateImageSrc(const QString &imgTag)
 {
-    if(imgTag.contains("<img")){
+    if(imgTag.contains("<img"))
+    {
         int begin = imgTag.indexOf("src=\"");
-        int end = imgTag.indexOf("\"",begin+6);
-        QString path = imgTag.mid(begin + 5,end-begin - 5);
+        int end = imgTag.indexOf("\"", begin + 6);
+        QString path = imgTag.mid(begin + 5, end - begin - 5);
         chatMessageData->setImagePath(path);
         return path;
     }
-    else{
+    else
+    {
         return imgTag;
     }
 

--- a/item_widgets/ChatMessageImageItemSelf.h
+++ b/item_widgets/ChatMessageImageItemSelf.h
@@ -1,6 +1,6 @@
 /**
   * @file ChatMessageImageItemSelf.h
-  * @brief 消息列表中的消息类型。纯图片类型，用于显示图片
+  * @brief 消息列表中的消息类型。纯图片类型，用于显示图片。显示在右边
   * @author zsj
   * @date 2021年3月2日09:22:59
   * @note 只用于显示图片。后续可以改进

--- a/item_widgets/ChatMessageImageItemSelf.h
+++ b/item_widgets/ChatMessageImageItemSelf.h
@@ -1,0 +1,74 @@
+/**
+  * @file ChatMessageImageItemSelf.h
+  * @brief 消息列表中的消息类型。纯图片类型，用于显示图片
+  * @author zsj
+  * @date 2021年3月2日09:22:59
+  * @note 只用于显示图片。后续可以改进
+  */
+#ifndef CHATMESSAGEIMAGEITEMSELF_H
+#define CHATMESSAGEIMAGEITEMSELF_H
+
+#include <QWidget>
+#include <QString>
+#include <QListWidget>
+
+#include "item_widgets/ChatMessageItem.h"
+#include "main/ChatMessageData.h"
+
+namespace Ui {
+class ChatMessageImageItemSelf;
+}
+
+class ChatMessageImageItemSelf : public QWidget,public zsj::ChatMessageItem
+{
+    Q_OBJECT
+
+public:
+    explicit ChatMessageImageItemSelf(QWidget *parent = nullptr);
+    ChatMessageImageItemSelf(zsj::ChatMessageData::ptr data,QListWidgetItem * item,
+                             QWidget * parent = nullptr);
+    ~ChatMessageImageItemSelf();
+
+    void adjustWidgetsPosition() override;
+    QSize calculateMessageWidgetSize() override;
+    QSize getWidgetSize()override;
+
+    /**
+     * @brief 每一次item变化后就需要重新贴图
+     */
+    void adjustImage();
+
+protected:
+    void resizeEvent(QResizeEvent *event);
+
+private:
+
+    void initResourceAndForm();
+
+    /**
+     * @brief 获取当前可显示的图片大小
+     * @param windowSize 当前窗口大小
+     * @return
+     */
+    QSize currentEnableImageSize(QSize windowSize);
+
+    /**
+     * @brief 将img标签中的src属性的值取出来
+     * @param imgTag 形如<img src="src" />
+     * @return
+     */
+    QString seprateImageSrc(const QString & imgTag);
+private:
+    Ui::ChatMessageImageItemSelf *ui;
+
+    QListWidgetItem * item;
+
+    /// 聊天对象的数据
+    zsj::ChatMessageData::ptr chatMessageData;
+
+
+    /// 显示的图片呢
+    QPixmap image;
+};
+
+#endif // CHATMESSAGEIMAGEITEMSELF_H

--- a/item_widgets/ChatMessageImageItemSelf.ui
+++ b/item_widgets/ChatMessageImageItemSelf.ui
@@ -1,29 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ChatMessageItemSelf</class>
- <widget class="QWidget" name="ChatMessageItemSelf">
+ <class>ChatMessageImageItemSelf</class>
+ <widget class="QWidget" name="ChatMessageImageItemSelf">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>60</height>
+    <width>406</width>
+    <height>78</height>
    </rect>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>0</width>
-    <height>60</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
+  <widget class="QLabel" name="labelHead">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>20</y>
+     <width>32</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>32</width>
+     <height>32</height>
+    </size>
+   </property>
+   <property name="maximumSize">
+    <size>
+     <width>32</width>
+     <height>32</height>
+    </size>
+   </property>
+   <property name="text">
+    <string>TextLabel</string>
+   </property>
+  </widget>
   <widget class="QWidget" name="widget" native="true">
    <property name="geometry">
     <rect>
-     <x>80</x>
-     <y>10</y>
+     <x>90</x>
+     <y>20</y>
      <width>72</width>
      <height>30</height>
     </rect>
@@ -71,31 +90,6 @@
      </widget>
     </item>
    </layout>
-  </widget>
-  <widget class="QLabel" name="labelHead">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>10</y>
-     <width>32</width>
-     <height>32</height>
-    </rect>
-   </property>
-   <property name="minimumSize">
-    <size>
-     <width>32</width>
-     <height>32</height>
-    </size>
-   </property>
-   <property name="maximumSize">
-    <size>
-     <width>32</width>
-     <height>32</height>
-    </size>
-   </property>
-   <property name="text">
-    <string>TextLabel</string>
-   </property>
   </widget>
  </widget>
  <resources/>

--- a/item_widgets/ChatMessageItem.cpp
+++ b/item_widgets/ChatMessageItem.cpp
@@ -1,6 +1,14 @@
 #include "ChatMessageItem.h"
 
-namespace zsj {
+#include <QString>
+#include <QFontMetrics>
+#include <QDebug>
+#include <QRegExp>
+
+#include "main/ChatBubble.h"
+
+namespace zsj
+{
 
 
 ChatMessageItem::ChatMessageItem()
@@ -12,4 +20,132 @@ ChatMessageItem::~ChatMessageItem()
 {
 
 }
+
+int ChatMessageItem::getContentMaxWidth(const QString &content, const int currWidth,
+                                        int &enterCount, const QFontMetrics &fm)
+{
+    /// @note 思考过于狭窄，只考虑了p标签。有可能不存在p标签
+//    const QString extraString = "<p></p>";
+//    int maxWidth = 0;
+//    int index = 0;
+//    enterCount = 0;
+//    do
+//    {
+//        int begin = content.indexOf("<p>",index);
+//        if(begin == -1){
+//            break;
+//        }
+//        int end = content.indexOf("</p>",begin);
+//        if(-1 == begin){
+//            break;
+//        }
+//        QString temp = content.mid(begin,end-begin + 4);
+
+//        int hasEmoji = false;
+//        int imgIndex = temp.indexOf("<img");
+//        if(-1 != imgIndex){
+//            int endImgIndex = temp.indexOf("/>",imgIndex);
+//            QString imgSrc = temp.mid(imgIndex,endImgIndex - imgIndex + 2);
+//            temp.replace(imgSrc,"");
+//            hasEmoji = true;
+//        }
+
+//        int width = fm.horizontalAdvance(temp) - fm.horizontalAdvance(extraString);
+//        if(hasEmoji){
+//            width += (zsj::ChatBubble::EmojiChatSize * 1.2);
+//        }
+//        if(width > currWidth - 90){
+//            maxWidth = currWidth - 90;
+//            int line = width / (currWidth - 90);
+//            int lineRemain  = width % (currWidth - 90);
+//            enterCount += (lineRemain ? line : line + 1);
+//        }
+//        else if(width > maxWidth){
+//            maxWidth = width;
+//        }
+//        // 有问题
+////        enterCount++;
+//        index = end + 4;
+//    }
+//    while(index < content.size());
+//    return maxWidth;
+
+    int maxWidth = 0;
+    int index = 0;
+    enterCount = 0;
+    bool onlyLine = true;
+
+    do
+    {
+        int pos = content.indexOf("\n", index);
+        if(-1 == pos && !onlyLine)
+        {
+            break;
+        }
+        else if(-1 == pos && onlyLine){
+            pos = content.size();
+            onlyLine = false;
+        }
+        QString line = content.mid(index, pos - index);
+        if(line.size() < 1){
+            break;
+        }
+        int width = getTagContentWidth(line, fm);
+        if(width > currWidth - 90)
+        {
+            maxWidth = currWidth - 90;
+            int line = width / (currWidth - 90);
+            int lineRemain  = width % (currWidth - 90);
+            enterCount += (lineRemain ? line : line + 1);
+        }
+        else if(width > maxWidth)
+        {
+            maxWidth = width;
+        }
+        enterCount++;
+        index = pos+1;
+    }
+    while(index != -1 &&index < content.size());
+    if(enterCount > 30){
+        enterCount += enterCount * 0.07;
+    }
+    return maxWidth;
+
+}
+
+int ChatMessageItem::getTagContentWidth(const QString &content, const QFontMetrics &fm)
+{
+    QRegExp rx("(</?\\w{0,10}>)");
+    QString tagList;
+    int pos = 0;
+
+    while ((pos = rx.indexIn(content, pos)) != -1) {
+        tagList.append(rx.cap(1));
+        pos += rx.matchedLength();
+    }
+    pos = 0;
+    int emojiCount = 0;
+    QString temp = content;
+    do{
+        int begin = content.indexOf("<img",pos);
+        if(-1 == begin){
+            break;
+        }
+        int end = content.indexOf("/>",begin);
+        if(-1 == end){
+            break;
+        }
+        QString imgTag = content.mid(begin,end - begin + 2);
+        temp.replace(imgTag,"");
+        emojiCount++;
+        pos = end;
+    }while(pos!=-1 && pos < content.size());
+    int width = fm.horizontalAdvance(temp) - fm.horizontalAdvance(tagList);
+    if(emojiCount>0){
+        width += (zsj::ChatBubble::EmojiChatSize * 1.2) * emojiCount;
+    }
+    return width;
+}
+
+
 }

--- a/item_widgets/ChatMessageItem.h
+++ b/item_widgets/ChatMessageItem.h
@@ -1,3 +1,9 @@
+/**
+  * @file ChatMessageItem.h
+  * @brief 显示聊天单条记录的item的基类。主要是处理自适应内容
+  * @author zsj
+  * @date 2021年3月3日09:48:30
+  */
 #ifndef CHATMESSAGEITEM_H
 #define CHATMESSAGEITEM_H
 
@@ -10,22 +16,24 @@ namespace zsj {
 class ChatMessageItem
 {
 public:
-    /**
-     * @brief HTML标签枚举，用于移除其样式匹配所用
-     * @note 后续有需要继续添加
-     */
-    enum TagType{
-        TAG_P = 0x0001,  // p标签
-        TAG_IMG = 0x0002, // img标签
-        TAG_SPAN = 0x0004, // span标签
-        TAG_BODY = 0x008,   //body标签
-        TAG_ALL = 0x1111    // 所有，用于运算
-    };
-public:
     ChatMessageItem();
 
+    /**
+     * @brief 计算内容容器（放置消息内容）的Size。
+     * @return
+     */
     virtual QSize calculateMessageWidgetSize() = 0;
+
+    /**
+     * @brief 获取布局容器（包含内容容器）的Size
+     * @return
+     * @note 需要先计算出内容容器的Size
+     */
     virtual QSize getWidgetSize() = 0;
+
+    /**
+     * @brief 设置布局容器的位置
+     */
     virtual void adjustWidgetsPosition() = 0;
 
     /**

--- a/item_widgets/ChatMessageItem.h
+++ b/item_widgets/ChatMessageItem.h
@@ -2,6 +2,7 @@
 #define CHATMESSAGEITEM_H
 
 #include <QSize>
+#include <QFontMetrics>
 
 namespace zsj {
 
@@ -9,13 +10,46 @@ namespace zsj {
 class ChatMessageItem
 {
 public:
+    /**
+     * @brief HTML标签枚举，用于移除其样式匹配所用
+     * @note 后续有需要继续添加
+     */
+    enum TagType{
+        TAG_P = 0x0001,  // p标签
+        TAG_IMG = 0x0002, // img标签
+        TAG_SPAN = 0x0004, // span标签
+        TAG_BODY = 0x008,   //body标签
+        TAG_ALL = 0x1111    // 所有，用于运算
+    };
+public:
     ChatMessageItem();
 
     virtual QSize calculateMessageWidgetSize() = 0;
     virtual QSize getWidgetSize() = 0;
     virtual void adjustWidgetsPosition() = 0;
 
-    ~ChatMessageItem();
+    /**
+     * @brief 获取内容换行的最大长度
+     * @param[in] content 内容
+     * @param[in] currWidth 当前长度
+     * @param[out] enterCount 换行的个数
+     * @param[in] fm 用于检测文字宽度
+     * @return
+     */
+    virtual int getContentMaxWidth(const QString & content,const int currWidth,
+                                   int &enterCount,const QFontMetrics & fm);
+
+
+    virtual ~ChatMessageItem();
+
+private:
+    /**
+     * @brief 获取标签内部的内容长度
+     * @param content 内容
+     * @param fm
+     * @return
+     */
+    int getTagContentWidth(const QString & content,const QFontMetrics & fm);
 
 };
 

--- a/item_widgets/ChatMessageItemObject.cpp
+++ b/item_widgets/ChatMessageItemObject.cpp
@@ -11,6 +11,7 @@ ChatMessageItemObject::ChatMessageItemObject(QWidget *parent) :
     item(nullptr)
 {
     ui->setupUi(this);
+    initResourceAndForm();
 }
 
 ChatMessageItemObject::ChatMessageItemObject(zsj::ChatMessageData::ptr data,
@@ -36,7 +37,10 @@ void ChatMessageItemObject::initResourceAndForm()
     QPixmap localHead = zsj::adjustToHead(ori, 32);
     ui->labelHead->setPixmap(localHead);
 
-    ui->labelMessage->setText(chatMessageData->getMessage());
+    ui->labelMessage->setText(chatMessageData->getMessage()
+                              .replace(
+                                  QString::number(zsj::ChatBubble::EmojiInputSize),
+                                  QString::number(zsj::ChatBubble::EmojiChatSize)));
 
     int fontSize = zsj::ChatBubble::Instance()->getBubbleFontSize();
 
@@ -56,17 +60,15 @@ void ChatMessageItemObject::adjustWidgetsPosition()
 QSize ChatMessageItemObject::calculateMessageWidgetSize()
 {
     QFont font = zsj::ChatBubble::Instance()->getBubbleFont();
-    QFont newFont(font.family(),font.pixelSize());
+    QFont newFont(font.family(), font.pixelSize());
     QFontMetrics fm(newFont);
     QString message = chatMessageData->getMessage();
-    int pixWidth = fm.horizontalAdvance(message);
-    int count = message.size();
-    int offset = (abs((pixWidth / count) - font.pixelSize())) * count;
-    pixWidth = pixWidth - offset;
-    int pixHeight = fm.height();
 
-    int col = (pixWidth / (this->width() - 90)) + 1;
-    int width  = col > 1 ? this->width() - 90 : pixWidth + 10;
+    // 去掉html标签中可能存在的内联样式。因为需要通过html来计算气泡的自适应宽度
+    message = zsj::HtmlUtil::RemoveOriginTagStyle(message, static_cast<zsj::TagType>(zsj::TAG_P | zsj::TAG_BODY | zsj::TAG_SPAN));
+    int pixHeight = fm.height();
+    int col = 0;
+    int width = getContentMaxWidth(message, this->width(), col, fm);
     int height = pixHeight * col - (pixHeight - font.pixelSize()) * col / 2;
 
     return QSize(width, height);

--- a/item_widgets/ChatMessageItemObject.cpp
+++ b/item_widgets/ChatMessageItemObject.cpp
@@ -7,8 +7,9 @@
 ChatMessageItemObject::ChatMessageItemObject(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::ChatMessageItemObject),
-    chatMessageData(nullptr),
-    item(nullptr)
+    item(nullptr),
+    chatMessageData(nullptr)
+
 {
     ui->setupUi(this);
     initResourceAndForm();
@@ -18,8 +19,9 @@ ChatMessageItemObject::ChatMessageItemObject(zsj::ChatMessageData::ptr data,
         QListWidgetItem *item, QWidget *parent) :
     QWidget(parent),
     ui(new Ui::ChatMessageItemObject),
-    chatMessageData(data),
-    item(item)
+    item(item),
+    chatMessageData(data)
+
 {
     ui->setupUi(this);
     initResourceAndForm();

--- a/item_widgets/ChatMessageItemObject.h
+++ b/item_widgets/ChatMessageItemObject.h
@@ -1,3 +1,9 @@
+/**
+  * @file ChatMessageItemSelf.h
+  * @brief 消息列表中的消息类型，显示消息和Emoji。显示在左边
+  * @author zsj
+  * @date 2021年3月3日09:57:18
+  */
 #ifndef CHATMESSAGEITEMOBJECT_H
 #define CHATMESSAGEITEMOBJECT_H
 

--- a/item_widgets/ChatMessageItemObject.ui
+++ b/item_widgets/ChatMessageItemObject.ui
@@ -29,6 +29,18 @@
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
+    <property name="leftMargin">
+     <number>10</number>
+    </property>
+    <property name="topMargin">
+     <number>9</number>
+    </property>
+    <property name="rightMargin">
+     <number>9</number>
+    </property>
+    <property name="bottomMargin">
+     <number>9</number>
+    </property>
     <item row="0" column="0">
      <widget class="QLabel" name="labelMessage">
       <property name="minimumSize">

--- a/item_widgets/ChatMessageItemSelf.cpp
+++ b/item_widgets/ChatMessageItemSelf.cpp
@@ -10,8 +10,9 @@
 ChatMessageItemSelf::ChatMessageItemSelf(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::ChatMessageItemSelf),
-    chatMessageData(nullptr),
-    item(nullptr)
+    item(nullptr),
+    chatMessageData(nullptr)
+
 {
     ui->setupUi(this);
     initResourceAndForm();
@@ -23,8 +24,8 @@ ChatMessageItemSelf::ChatMessageItemSelf(zsj::ChatMessageData::ptr data,
         QListWidgetItem *item, QWidget *parent) :
     QWidget(parent),
     ui(new Ui::ChatMessageItemSelf),
-    chatMessageData(data),
-    item(item)
+    item(item),
+    chatMessageData(data)
 {
     ui->setupUi(this);
     initResourceAndForm();
@@ -47,7 +48,7 @@ void ChatMessageItemSelf::initResourceAndForm()
                                   QString::number(zsj::ChatBubble::EmojiChatSize)));
 
     // 清楚所有标签内联样式
-    QString clearMessage = zsj::HtmlUtil::RemoveOriginTagStyle(chatMessageData->getMessage(),static_cast<zsj::TagType>(zsj::TAG_ALL));
+    QString clearMessage = zsj::HtmlUtil::RemoveOriginTagStyle(chatMessageData->getMessage(), static_cast<zsj::TagType>(zsj::TAG_ALL));
     chatMessageData->setMessage(clearMessage);
 
 

--- a/item_widgets/ChatMessageItemSelf.h
+++ b/item_widgets/ChatMessageItemSelf.h
@@ -22,7 +22,8 @@ public:
     explicit ChatMessageItemSelf(QWidget *parent = nullptr);
     ~ChatMessageItemSelf();
 
-    ChatMessageItemSelf(zsj::ChatMessageData::ptr data, QListWidgetItem *item, QWidget *parent = nullptr);
+    ChatMessageItemSelf(zsj::ChatMessageData::ptr data, QListWidgetItem *item,
+                        QWidget *parent = nullptr);
 
 
     void adjustWidgetsPosition()override;
@@ -42,6 +43,7 @@ private:
 
     /// 聊天对象的数据  包括聊天信息、头像
     zsj::ChatMessageData::ptr chatMessageData;
+
 };
 
 #endif // CHATMESSAGEITEMSELF_H

--- a/item_widgets/ChatMessageItemSelf.h
+++ b/item_widgets/ChatMessageItemSelf.h
@@ -2,7 +2,12 @@
 #define CHATMESSAGEITEMSELF_H
 
 #include <QWidget>
-
+/**
+  * @file ChatMessageItemSelf.h
+  * @brief 消息列表中的消息类型，显示消息和Emoji。显示在右边
+  * @author zsj
+  * @date 2021年3月3日09:57:18
+  */
 #include <QListWidgetItem>
 #include <QSize>
 
@@ -31,6 +36,10 @@ public:
     QSize getWidgetSize()override;
 
 protected:
+    /**
+     * @brief 每次触发这个信号时，需要重新设置各个widget的大小和位置
+     * @param event
+     */
     void resizeEvent(QResizeEvent *event);
 
 private:

--- a/item_widgets/ChatObjectItem.h
+++ b/item_widgets/ChatObjectItem.h
@@ -1,3 +1,9 @@
+/**
+  * @file ChatObjectItem.h
+  * @brief 聊天窗口左边的聊天对象列表中的item对象。
+  * @author zsj
+  * @date 2021年3月3日09:58:35
+  */
 #ifndef CHATOBJECTITEM_H
 #define CHATOBJECTITEM_H
 
@@ -25,8 +31,6 @@ public:
     /// @return QRect
     QRect getDeleteButtonPosition() const;
 
-    int getIndex() const;
-
 protected:
 
     void resizeEvent(QResizeEvent *);
@@ -50,6 +54,7 @@ private:
 private:
     Ui::ChatObjectItem *ui;
 
+    /// 聊天对象的数据
     zsj::Data::ptr data;
 
 public slots:

--- a/main.cpp
+++ b/main.cpp
@@ -16,19 +16,25 @@
 #include <QtGlobal>
 #include <QTime>
 
+#define TEST 0
+
 void outputMessage(QtMsgType type, const QMessageLogContext &context, const QString &msg);
 void printAppInfo();
 
 int main(int argc, char *argv[])
 {
-    QApplication a(argc, argv);
-
-
 
 #ifdef DEBUG
     qsrand(QTime(0, 0, 0).secsTo(QTime::currentTime()));
     // msg
 #endif
+#if TEST
+
+    zsj::Test().test();
+#else
+    QApplication a(argc, argv);
+
+
     //安装日志处理钩子函数
     qInstallMessageHandler(outputMessage);
 
@@ -43,9 +49,9 @@ int main(int argc, char *argv[])
     ChatWidget chatWidget;
     chatWidget.show();
 
-    zsj::Test().test();
+//    zsj::Test().test();
     return a.exec();
-
+#endif
 }
 
 void outputMessage(QtMsgType type, const QMessageLogContext &context, const QString &msg)

--- a/main/ChatBubble.cpp
+++ b/main/ChatBubble.cpp
@@ -12,8 +12,8 @@ QScopedPointer<ChatBubble> ChatBubble::chatBubble;
 ChatBubble::ChatBubble()
 {
     bubblePadding = 9;
-    bubbleFont = QFont("微软雅黑",14);
-    bubbleFont.setPixelSize(14);
+    bubbleFont = QFont("微软雅黑",FontSize);
+    bubbleFont.setPixelSize(FontSize);
 }
 
 QFont ChatBubble::getBubbleFont() const

--- a/main/ChatBubble.h
+++ b/main/ChatBubble.h
@@ -13,6 +13,13 @@ class ChatBubble
 {
 public:
     static ChatBubble * Instance();
+
+    /// 气泡、聊天输入框字体大小
+    static const uint FontSize = 18;
+    /// 聊天输入框的表情大小
+    static const uint EmojiInputSize = 28;
+    /// 消息列表的表情大小
+    static const uint EmojiChatSize = 22;
 public:
     uint getBubblePadding() const;
     void setBubblePadding(const uint &value);

--- a/main/ChatMessageData.cpp
+++ b/main/ChatMessageData.cpp
@@ -1,6 +1,7 @@
 #include "ChatMessageData.h"
 
-namespace zsj {
+namespace zsj
+{
 
 
 
@@ -9,9 +10,16 @@ ChatMessageData::ChatMessageData()
 
 }
 
-ChatMessageData::ChatMessageData(QPixmap &head, const QString &message) :
+ChatMessageData::ChatMessageData(const QString &imagePath, QPixmap &head):
+    head(head), imagePath(imagePath)
+{
+
+}
+
+ChatMessageData::ChatMessageData(QPixmap &head, const QString &message, bool hasEmoji) :
     head(head),
-    message(message)
+    message(message),
+    hasEmoji(hasEmoji)
 {
 
 }
@@ -35,4 +43,25 @@ void ChatMessageData::setMessage(const QString &value)
 {
     message = value;
 }
+
+bool ChatMessageData::getHasEmoji() const
+{
+    return hasEmoji;
+}
+
+void ChatMessageData::setHasEmoji(bool value)
+{
+    hasEmoji = value;
+}
+
+QString ChatMessageData::getImagePath() const
+{
+    return imagePath;
+}
+
+void ChatMessageData::setImagePath(const QString &value)
+{
+    imagePath = value;
+}
+
 }

--- a/main/ChatMessageData.h
+++ b/main/ChatMessageData.h
@@ -14,7 +14,21 @@ class ChatMessageData
 public:
     typedef QSharedPointer<ChatMessageData> ptr;
     ChatMessageData();
-    ChatMessageData(QPixmap &head, const QString &message);
+
+    /**
+     * @brief 用于构建显示图片的item
+     * @param imagePath 图片路径
+     * @param head 头像
+     */
+    ChatMessageData(const QString &imagePath,QPixmap &head);
+
+    /**
+     * @brief 用于构建显示消息的item
+     * @param head 头像
+     * @param message 消息
+     * @param hasEmoji 消息中是否含有表情
+     */
+    ChatMessageData(QPixmap &head, const QString &message,bool hasEmoji = false);
 
 
     QPixmap getHead() const;
@@ -23,9 +37,20 @@ public:
     QString getMessage() const;
     void setMessage(const QString &value);
 
+
+    bool getHasEmoji() const;
+    void setHasEmoji(bool value);
+
+    QString getImagePath() const;
+    void setImagePath(const QString &value);
+
 private:
     QPixmap head;
     QString message;
+    QString imagePath;
+
+    /// 当前聊天记录中是否有表情
+    bool hasEmoji;
 };
 
 }

--- a/main/CurrentWindow.cpp
+++ b/main/CurrentWindow.cpp
@@ -1,0 +1,38 @@
+#include "CurrentWindow.h"
+
+#include <QMutex>
+#include <QMutexLocker>
+
+namespace zsj {
+
+
+QScopedPointer<CurrentWindow> CurrentWindow::currentWindow;
+
+CurrentWindow::CurrentWindow()
+{
+
+}
+
+CurrentWindow *CurrentWindow::Instance()
+{
+    if(currentWindow.isNull()){
+        static QMutex mutex;
+        QMutexLocker locker(&mutex);
+        if(currentWindow.isNull()){
+            currentWindow.reset(new CurrentWindow);
+        }
+    }
+    return currentWindow.data();
+}
+
+QRect CurrentWindow::getWindowGeometry() const
+{
+    return windowGeometry;
+}
+
+void CurrentWindow::setWindowGeometry(const QRect &value)
+{
+    windowGeometry = value;
+}
+
+}

--- a/main/CurrentWindow.h
+++ b/main/CurrentWindow.h
@@ -1,0 +1,36 @@
+/**
+  * @file CurrentWindow.h
+  * @brief 记录当前窗口的信息。
+  * @author zsj
+  * @date 2021年3月2日09:43:58
+  * @note 目前记录当前窗口的geometry。
+  */
+#ifndef CURRENTWINDOW_H
+#define CURRENTWINDOW_H
+
+#include <QSize>
+#include <QScopedPointer>
+#include <QRect>
+
+namespace zsj {
+
+
+class CurrentWindow
+{
+public:
+    static CurrentWindow * Instance();
+public:
+
+    QRect getWindowGeometry() const;
+    void setWindowGeometry(const QRect &value);
+
+private:
+    CurrentWindow();
+private:
+    static QScopedPointer<CurrentWindow> currentWindow;
+
+    QRect windowGeometry;
+};
+
+}
+#endif // CURRENTWINDOW_H

--- a/main/StaticIniator.cpp
+++ b/main/StaticIniator.cpp
@@ -13,7 +13,7 @@ namespace zsj {
 
 QScopedPointer<StaticIniator> StaticIniator::staticIniator;
 
-StaticIniator *StaticIniator::Instatcne()
+StaticIniator *StaticIniator::Instance()
 {
     if(staticIniator.isNull()){
         static QMutex mutex;

--- a/main/StaticIniator.h
+++ b/main/StaticIniator.h
@@ -19,7 +19,7 @@ class StaticIniator : public QObject
 {
     Q_OBJECT
 public:
-    static StaticIniator * Instatcne();
+    static StaticIniator * Instance();
 public:
 
     void initFirendMenu(QMenu * menu,QWidget * owner);

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -14,10 +14,15 @@
 #include <queue>
 #include <QPair>
 
+#include <QRegExp>
+
+#include <QFile>
+
 #include "main/ReadQStyleSheet.h"
 #include "utils/Util.h"
 
-namespace zsj {
+namespace zsj
+{
 
 Test::Test()
 {
@@ -29,14 +34,19 @@ void Test::test()
 //    testQApplication();
 //    testFile();
 //    testDir();
-    testDebugColor();
+//    testDebugColor();
+//    findSubString();
+//    testStringReplace();
+//    testRemoveStyle();
+//    testReg();
+    testFontWidth();
 }
 
 void Test::testQApplication()
 {
     QString appName = qApp->applicationName();
-    quint64 pid= qApp->applicationPid();
-    QWidget * screen = qApp->desktop()->screen();
+    quint64 pid = qApp->applicationPid();
+    QWidget *screen = qApp->desktop()->screen();
     qDebug() << appName;
     qDebug() << pid;
     qDebug() << screen->width() << ":" << screen->height();
@@ -53,10 +63,12 @@ void Test::testFile()
 void Test::testDir()
 {
     bool isOk = zsj::FileUtil::judgeAndMakeDir("D:/TestDir/test1");
-    if(isOk){
+    if(isOk)
+    {
         qDebug() << "mkdir ok";
     }
-    else{
+    else
+    {
         qDebug() << "mkdir failed";
     }
 }
@@ -94,6 +106,77 @@ void Test::testQueue()
 void Test::testDebugColor()
 {
     qDebug() << "\033[36m" << "hello";
+}
+
+void Test::findSubString()
+{
+    QString originString = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\np, li { white-space: pre-wrap; }\n</style></head><body style=\" font-family:'SimSun'; font-size:9pt; font-weight:400; font-style:normal;\">\n<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">hkl看看剧来看<img src=\":/symbol/res/emoji/symbol/b_m.png\" width=\"28\" height=\"28\" />奥术大师大所多<img src=\"D:/QT/QtCode/MySelfQQ_v2/build/build-MySelfQQ_v2-Desktop_Qt_5_12_0_MinGW_64_bit-Debug/debug/screen_shot/2021-03-01-11-40-51.jpg\" width=\"150\" height=\"90\" /></p></body></html>";
+    int begin = originString.indexOf("<body");
+    int end = originString.indexOf("</body>");
+    const int lastCount = QString("</p></body></html>").size();
+    qDebug() << begin << " - " << end << " - " << originString.size();
+    qDebug() << originString.mid(begin);
+}
+
+void Test::testStringReplace()
+{
+    QString str = "<img src=':/normal/res/emoji/normal/biz.png' width=28 height=28></img>";
+    QString temp = str.replace("28", "16");
+    qDebug() << "temp : " << temp;
+    qDebug() << "str:   " << str;
+}
+
+void Test::testRemoveStyle()
+{
+
+    qDebug() << (0x001F00 & 0x000100);
+    QString path = "Z:\\default\\Desktop\\temp.html";
+    path = path.toLocal8Bit();
+    qDebug() << path.toStdString().data();
+    QFile file(path);
+    if(!file.open(QIODevice::ReadOnly))
+    {
+        qCritical() << "file open failed!";
+        return;
+    }
+    QString originStr = QString(file.readAll().toStdString().data());
+    QString result = zsj::HtmlUtil::RemoveOriginTagStyle(originStr, static_cast<zsj::TagType>(
+                         zsj::TAG_ALL));
+    qDebug() << result;
+}
+
+void Test::testReg()
+{
+    QString origin = "<body><h3><span>重要事务</span></h3>";
+    QRegExp rx("(</?\\w{0,10}>)");
+    QStringList list;
+    int pos = 0;
+
+    while ((pos = rx.indexIn(origin, pos)) != -1) {
+        list << rx.cap(1);
+        pos += rx.matchedLength();
+    }
+    qDebug() << list;
+}
+
+void Test::testFontWidth()
+{
+    QFont font = QFont("微软雅黑",18);
+    QFont newFont(font.family(), font.pixelSize());
+    QFontMetrics fm(newFont);
+    QString testStr = "[测试字符]";
+    int height = fm.height();
+    int pixSize = font.pixelSize();
+    int pointSize = font.pointSize();
+    qDebug() << "pixSize: " << pixSize << " "
+             << "pointSize:" << pointSize;  // -1 18
+    int width = fm.width("[");
+    qDebug() << "height: " << height << "  "
+             << "width:  " << width; // 21 5
+    int sizeWidth = height * testStr.size();
+    int pixWidth = fm.horizontalAdvance(testStr);
+    qDebug() << "sizeWidth: " << sizeWidth << "  "
+             << "pixWidth: " << pixWidth; //126  74
 }
 
 

--- a/test/Test.h
+++ b/test/Test.h
@@ -24,6 +24,19 @@ private:
     void testQueue();
 
     void testDebugColor();
+
+
+    void findSubString();
+
+    void testStringReplace();
+
+
+    void testRemoveStyle();
+
+
+    void testReg();
+
+    void testFontWidth();
 };
 
 }

--- a/utils/Global.h
+++ b/utils/Global.h
@@ -34,6 +34,9 @@ enum class UiType{
 
 
 
+
+
+
 /// 默认的菜单项的透明icon的路径，为了对齐菜单项
 /// 如果一些菜单有icon，一些没有，则菜单项文字对不齐
 const static QString transparentMenuIconPath =":/main/res/main/transparent.png";

--- a/utils/Util.cpp
+++ b/utils/Util.cpp
@@ -21,19 +21,28 @@ QSize Util::ScaledImageSize(const QSize &originSize, int max)
 {
     int realHeight = originSize.height();
     int realWidth = originSize.width();
-    if(originSize.height() > originSize.width()){
-        if(originSize.height() > max){
+    if(originSize.height() > originSize.width())
+    {
+        if(originSize.height() > max)
+        {
             realHeight = max;
             realWidth = max * 1.0 / originSize.height() * originSize.width();
         }
     }
-    else{
-        if(originSize.width() > max){
+    else
+    {
+        if(originSize.width() > max)
+        {
             realWidth = max;
             realHeight = max * 1.0 / originSize.width() * originSize.height();
         }
     }
-    return QSize(realWidth,realHeight);
+    return QSize(realWidth, realHeight);
+}
+
+QString Util::PackageImageHtml(const QString &src, int width, int height)
+{
+    return QString("<img src='%1' width=%2 height=%3 />").arg(src).arg(width).arg(height);
 }
 
 
@@ -184,6 +193,47 @@ bool FileUtil::judgeAndMakeDir(const QString &dirPath)
         }
     }
     return false;
+}
+
+QString HtmlUtil::RemoveOriginTagStyle(const QString &originStr, TagType types)
+{
+
+    QString result = originStr;
+    for(auto iter = TagName.begin(); iter != TagName.end(); ++iter)
+    {
+        if(types & iter.value())
+        {
+            RemoveStyle(iter.key(), result);
+        }
+    }
+    return result;
+}
+
+QString HtmlUtil::GetHtmlBodyContent(const QString &html)
+{
+    int begin = html.indexOf("<body");
+    int bodyEnd = html.indexOf("</body>", begin);
+    QString content = html.mid(begin, bodyEnd - begin + 7);
+    return content;
+}
+
+void HtmlUtil::RemoveStyle(const QString &tag, QString &originStr)
+{
+    int index = 0;
+    do
+    {
+        int begin = originStr.indexOf(QString("<%1 ").arg(tag), index);
+        if(-1 == begin)
+        {
+            break;
+        }
+        int offset = QString(tag).size() + 1;
+        int end = originStr.indexOf(">", begin + offset);
+        QString temp = originStr.mid(begin, end - begin + 1);
+        originStr.replace(temp, QString("<%1>").arg(tag));
+        index = end;
+    }
+    while(index < originStr.size());
 }
 
 

--- a/utils/Util.h
+++ b/utils/Util.h
@@ -12,6 +12,7 @@
 #include <QWidget>
 #include <utility>
 #include <QDebug>
+#include <QMap>
 
 #include "utils/Global.h"
 
@@ -33,6 +34,15 @@ public:
      * @note 主要用于截图后粘贴到输入框中
      */
     static QSize ScaledImageSize(const QSize & originSize,int max = 150 );
+
+    /**
+     * @brief 将文件路径打包为html中的<src>样式
+     * @param src 文件路径
+     * @param width 宽
+     * @param height 高
+     * @return <img src="#src" width=#width height=#height />
+     */
+    static QString PackageImageHtml(const QString & src,int width,int height);
 };
 
 struct HeadSize
@@ -125,6 +135,75 @@ public:
     static bool judgeAndMakeDir(const QString & dirPath);
 };
 
+
+
+
+
+/**
+ * @brief HTML标签枚举，用于移除其样式匹配所用
+ * @note 后续有需要继续添加
+ */
+enum TagType{
+    TAG_P           = 0x000001,         // p标签
+    TAG_IMG         = 0x000000,         // img标签
+    TAG_SPAN        = 0x000004,         // span标签
+    TAG_BODY        = 0x000008,         // body标签
+    TAG_H1          = 0x000010,         // h4
+    TAG_H2          = 0x000020,         // h4
+    TAG_H3          = 0x000040,         // h3
+    TAG_H4          = 0x000080,         // h4
+    TAG_H5          = 0x000100,         // h5
+    TAG_ALL_H       = 0x0001F0,         // 所有h标签
+    TAG_UL          = 0x000200,         // ul
+    TAG_OL          = 0x000400,         // ol
+    TAG_LI          = 0x000800,         // li
+    TAG_ALL_TABLE   = 0x000E00,         // 所有表格标签
+    TAG_ALL         = 0xFFFFFF          // 所有，用于运算
+};
+
+static const QMap<QString,TagType> TagName = {
+    {"p",TAG_P},
+    {"span",TAG_SPAN},
+    {"body",TAG_BODY},
+    {"h1",TAG_H1},{"h2",TAG_H2},{"h3",TAG_H3},{"h4",TAG_H4},{"h5",TAG_H5},
+    {"ul",TAG_UL},{"ol",TAG_OL},{"li",TAG_LI}
+};
+
+
+static const QMap<TagType,QString> NameTag = {
+    {TAG_P,"p"},
+    {TAG_SPAN,"span"},
+    {TAG_BODY,"body"},
+    {TAG_H1,"h1"},{TAG_H2,"h2"},{TAG_H3,"h3"},{TAG_H4,"h4"},{TAG_H5,"h5"},
+    {TAG_UL,"ul"},{TAG_OL,"ol"},{TAG_LI,"li"}
+};
+
+class HtmlUtil{
+public:
+    /**
+     * @brief 移除HTML标签中Qt自带的style样式
+     * @param originStr 原始字符串
+     * @param types 需要移除样式的标签
+     * @return
+     * @note 移除样式之后方便计算其宽度
+     */
+    static QString RemoveOriginTagStyle(const QString & originStr,TagType types);
+
+    /**
+     * @brief 获取html文档中的body内容
+     * @param html html文档
+     * @return
+     */
+    static QString GetHtmlBodyContent(const QString & html);
+
+private:
+    /**
+     * @brief 移除标签的内联样式
+     * @param types 需要移除的标签类型
+     * @param originStr
+     */
+    static void RemoveStyle(const QString & tag,QString & originStr);
+};
 
 
 /// @brief 将QPixmap转换为圆形


### PR DESCRIPTION
# 修复气泡自适应bug
* 当前气泡可以正常适应文字宽高和图片宽高
* 当前气泡可以支持显示`markdown`内容，但支持的`html`只到`html2`
* 当前气泡的样式和输入框的样式相同，因为是直接使用的`html`格式。
* 剩下没解决的bug
  - 气泡的内容如果是英文符号，则自适应宽度会出现问题。会短一截