### PR TITLE
修复账号下拉框析构时崩溃的异常

### DIFF
--- a/LoginWidget.cpp
+++ b/LoginWidget.cpp
@@ -75,6 +75,9 @@ void LoginWidget::deleteObjects()
 
     delete infoDao;
     infoDao = nullptr;
+
+    delete popupWidget;
+    popupWidget = nullptr;
 }
 
 void LoginWidget::loadAndSetLoginInfo()
@@ -93,16 +96,17 @@ void LoginWidget::loadAndSetLoginInfo()
         }
         for(int i = 0; i < infos.size(); i++)
         {
-            qDebug() << infos.at(i).toString();
-            QPixmap pix(infos.at(i).getHead());
-            QPixmap head = zsj::adjustToHead(pix, zsj::HeadSize::loginItemDiameter);
-            ComboBoxItemWidget *item = new  ComboBoxItemWidget(std::make_shared<zsj::LoginInfo>(infos.at(i)),
-                    comboBoxListWidget);
-            item->setFixedSize(235, 50);
-            QListWidgetItem *widgetItem = new QListWidgetItem(comboBoxListWidget);
-            connect(item, &ComboBoxItemWidget::sigClick, this, &LoginWidget::slotSetAccountAndPassword);
-            comboBoxListWidget->setItemWidget(widgetItem, item);
-            widgetItem->setSizeHint(QSize(235, 50));
+//            qDebug() << infos.at(i).toString();
+//            QPixmap pix(infos.at(i).getHead());
+//            QPixmap head = zsj::adjustToHead(pix, zsj::HeadSize::loginItemDiameter);
+//            ComboBoxItemWidget *item = new  ComboBoxItemWidget(std::make_shared<zsj::LoginInfo>(infos.at(i)),
+//                    comboBoxListWidget);
+//            item->setFixedSize(235, 50);
+//            QListWidgetItem *widgetItem = new QListWidgetItem(comboBoxListWidget);
+//            connect(item, &ComboBoxItemWidget::sigClick, this, &LoginWidget::slotSetAccountAndPassword);
+//            comboBoxListWidget->setItemWidget(widgetItem, item);
+//            widgetItem->setSizeHint(QSize(235, 50));
+            popupWidget->addItem(infos.at(i));
         }
     }
     else
@@ -215,34 +219,15 @@ void LoginWidget::initSignalsAndSlots()
 
 
     connect(ui->pushButtonDropDown, &QPushButton::clicked, this, &LoginWidget::slotShowComboBoxPopus);
-    connect(popupWidget,&PopupWidget::sigHide,this,[=](){
+    connect(popupWidget, &PopupWidget::sigHide, this, [ = ]()
+    {
         ui->pushButtonDropDown->setChecked(false);
     });
     qInfo() << "connect QPushButton cliecked to LoginWidget::slotShowComboBoxPopus";
 
-//    connect(ui->comboBoxAccount, &MyComboBox::setLineEditCssOn, this, [ = ]()
-//    {
-//        ui->lineEditOuterInput->setStyleSheet("#lineEditOuterInput{border-bottom:1px solid rgb(18,183,245);"
-//                                              "background:left top no-repeat url('://res/login/logo2.png');}");
-//        ui->pushButtonDropDown->setStyleSheet("background:url('://res/login/arrow-on.png');");
-//    });
+    connect(popupWidget, &PopupWidget::sigClick, this, &LoginWidget::slotSetAccountAndPassword);
+
     qInfo() << "connect MyComboBox::setLineEditCssOn to lambda func to set css";
-
-    /// 设置密码框的样式
-//    connect(ui->comboBoxAccount, &MyComboBox::setLineEditCssOff, this, [ = ]()
-//    {
-//        ui->lineEditOuterInput->setStyleSheet("#lineEditOuterInput{border-bottom:1px solid rgb(229,229,229);"
-//                                              "background:left top no-repeat url('://res/login/logo1.png');}"
-//                                              "#lineEditOuterInput:hover{border-bottom:1px solid rgb(193,193,193);}"
-//                                              "#lineEditOuterInput:focus{border-bottom:1px solid rgb(18,183,245);"
-//                                              "background:left top no-repeat url('://res/login/logo2.png');}");
-//        ui->pushButtonDropDown->setStyleSheet("#pushButtonDropDown{background:url('://res/login/arrow.png');}"
-//                                              "#pushButtonDropDown:hover{background:url('://res/login/arrow-hover.png');}");
-//        ui->comboBoxAccount->view()->verticalScrollBar()->setSliderPosition(0);  // 将滚动条复位
-//    });
-    qInfo() << "connect MyComboBox::setLineEditCssOff to lambda func to set css";
-
-
     connect(ui->toolButtonMin, &QToolButton::clicked, this, &LoginWidget::slotMinWindow);
     connect(ui->toolButtonMinLogin, &QToolButton::clicked, this, &LoginWidget::slotMinWindow);
     connect(ui->toolButtonMinLoginError, &QToolButton::clicked, this, &LoginWidget::slotMinWindow);
@@ -286,24 +271,23 @@ void LoginWidget::slotMinWindow()
 void LoginWidget::slotSetAccountAndPassword(zsj::LoginInfo::ptr info)
 {
     QPixmap pix(info->getHead());
-    QPixmap head = zsj::adjustToHead(pix, zsj::HeadSize::loginItemDiameter);
+    QPixmap head = zsj::adjustToHead(pix, zsj::HeadSize::loginMainDiameter);
     ui->labelHeadImage->setPixmap(head);
     ui->lineEditOuterInput->setText(QString::number(info->getAccount()));
 //    ui->comboBoxAccount->setCurrentText(QString::number(info->getAccount()));
     ui->lineEditPwd->setText(info->getPassword());
     ui->checkBoxAutoLogin->setChecked(info->getAutoLogin());
     ui->checkBoxRememberPwd->setChecked(info->getSavePassword());
+
+    popupWidget->hide();
 }
 
 void LoginWidget::slotShowComboBoxPopus()
 {
-//    ui->comboBoxAccount->showPopup();
-    if(!ui->pushButtonDropDown->isChecked()){
-        qDebug() << "unchecked";
+    if(popupWidget->isVisible()){
         popupWidget->hide();
     }
     else{
-        qDebug() << "checked";
         popupWidget->showWindow();
     }
 }

--- a/LoginWidget.cpp
+++ b/LoginWidget.cpp
@@ -58,6 +58,8 @@ void LoginWidget::initObjects()
 
     frameless = new zsj::Frameless(this);
     frameless->setResizeEnable(false);
+
+    popupWidget = new PopupWidget(ui->lineEditOuterInput);
 }
 
 void LoginWidget::deleteObjects()
@@ -172,13 +174,13 @@ void LoginWidget::initResourceAndForm()
 
     comboBoxListWidget->setFixedHeight(180);
     comboBoxListWidget->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-    ui->comboBoxAccount->setModel(comboBoxListWidget->model());
-    ui->comboBoxAccount->setView(comboBoxListWidget);
-    ui->comboBoxAccount->setMaxVisibleItems(3);         //配合CSS显示下拉框正确高度
+//    ui->comboBoxAccount->setModel(comboBoxListWidget->model());
+//    ui->comboBoxAccount->setView(comboBoxListWidget);
+//    ui->comboBoxAccount->setMaxVisibleItems(3);         //配合CSS显示下拉框正确高度
 
-    // 将视图的父窗口设置为透明的，目的是让QComboBox的下拉框透明  需要配合css
-    ui->comboBoxAccount->view()->parentWidget()->setWindowFlags(/*Qt::Popup |*/ Qt::FramelessWindowHint);
-    ui->comboBoxAccount->view()->parentWidget()->setAttribute(Qt::WA_TranslucentBackground);
+//    // 将视图的父窗口设置为透明的，目的是让QComboBox的下拉框透明  需要配合css
+//    ui->comboBoxAccount->view()->parentWidget()->setWindowFlags(/*Qt::Popup |*/ Qt::FramelessWindowHint);
+//    ui->comboBoxAccount->view()->parentWidget()->setAttribute(Qt::WA_TranslucentBackground);
 
 
 //    for(int i = 0; i < 5; i++)
@@ -211,7 +213,11 @@ void LoginWidget::initSignalsAndSlots()
     connect(ui->toolButtonCloseLoginError, &QToolButton::clicked, this, &LoginWidget::slotCloseWindow);
     qInfo() << "connect toolButtonClose clicked to LoginWidget::slotCloseWindow";
 
+
     connect(ui->pushButtonDropDown, &QPushButton::clicked, this, &LoginWidget::slotShowComboBoxPopus);
+    connect(popupWidget,&PopupWidget::sigHide,this,[=](){
+        ui->pushButtonDropDown->setChecked(false);
+    });
     qInfo() << "connect QPushButton cliecked to LoginWidget::slotShowComboBoxPopus";
 
 //    connect(ui->comboBoxAccount, &MyComboBox::setLineEditCssOn, this, [ = ]()
@@ -283,7 +289,7 @@ void LoginWidget::slotSetAccountAndPassword(zsj::LoginInfo::ptr info)
     QPixmap head = zsj::adjustToHead(pix, zsj::HeadSize::loginItemDiameter);
     ui->labelHeadImage->setPixmap(head);
     ui->lineEditOuterInput->setText(QString::number(info->getAccount()));
-    ui->comboBoxAccount->setCurrentText(QString::number(info->getAccount()));
+//    ui->comboBoxAccount->setCurrentText(QString::number(info->getAccount()));
     ui->lineEditPwd->setText(info->getPassword());
     ui->checkBoxAutoLogin->setChecked(info->getAutoLogin());
     ui->checkBoxRememberPwd->setChecked(info->getSavePassword());
@@ -291,7 +297,15 @@ void LoginWidget::slotSetAccountAndPassword(zsj::LoginInfo::ptr info)
 
 void LoginWidget::slotShowComboBoxPopus()
 {
-    ui->comboBoxAccount->showPopup();
+//    ui->comboBoxAccount->showPopup();
+    if(!ui->pushButtonDropDown->isChecked()){
+        qDebug() << "unchecked";
+        popupWidget->hide();
+    }
+    else{
+        qDebug() << "checked";
+        popupWidget->showWindow();
+    }
 }
 
 void LoginWidget::slotLogin()

--- a/LoginWidget.h
+++ b/LoginWidget.h
@@ -19,6 +19,7 @@
 #include "item_widgets/ComboBoxItemWidget.h"
 #include "feature_widgets/SystemTray.h"
 #include "feature_widgets/ToolTipWidget.h"
+#include "feature_widgets/PopupWidget.h"
 #include "main/Frameless.h"
 #include "main/Data.h"
 #include "dao/LoginInfoDao.h"
@@ -82,6 +83,9 @@ private:
 
     /// 当前登录用户的信息
     QVector<zsj::LoginInfo> infos;
+
+
+    PopupWidget * popupWidget;
 signals:
     /**
      * @brief 登录成功时发送信号

--- a/LoginWidget.h
+++ b/LoginWidget.h
@@ -85,6 +85,7 @@ private:
     QVector<zsj::LoginInfo> infos;
 
 
+    /// 下拉框  账号输入框的下拉框
     PopupWidget * popupWidget;
 signals:
     /**

--- a/LoginWidget.ui
+++ b/LoginWidget.ui
@@ -333,7 +333,10 @@
           <string/>
          </property>
          <property name="checkable">
-          <bool>true</bool>
+          <bool>false</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
          </property>
         </widget>
        </widget>

--- a/LoginWidget.ui
+++ b/LoginWidget.ui
@@ -272,19 +272,6 @@
           <bool>true</bool>
          </property>
         </widget>
-        <widget class="QComboBox" name="comboBoxAccount">
-         <property name="geometry">
-          <rect>
-           <x>90</x>
-           <y>50</y>
-           <width>250</width>
-           <height>24</height>
-          </rect>
-         </property>
-         <property name="editable">
-          <bool>true</bool>
-         </property>
-        </widget>
         <widget class="QLineEdit" name="lineEditPwd">
          <property name="geometry">
           <rect>
@@ -344,6 +331,9 @@
          </property>
          <property name="text">
           <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
          </property>
         </widget>
        </widget>

--- a/MySelfQQ_v2.pro
+++ b/MySelfQQ_v2.pro
@@ -70,7 +70,8 @@ SOURCES += main.cpp \
     dao/LoginInfoDao.cpp \
     database/DataBase.cpp \
     database/SQLiteDataBase.cpp \
-    main/LoginInfo.cpp
+    main/LoginInfo.cpp \
+    feature_widgets/PopupWidget.cpp
 
 
 
@@ -131,7 +132,8 @@ HEADERS  += ChatWidget.h \
     dao/LoginInfoDao.h \
     database/DataBase.h \
     database/SQLiteDataBase.h \
-    main/LoginInfo.h
+    main/LoginInfo.h \
+    feature_widgets/PopupWidget.h
 
 
 FORMS    +=     LoginWidget.ui \
@@ -150,7 +152,8 @@ FORMS    +=     LoginWidget.ui \
     item_widgets/ChatMessageFileItemObject.ui \
     item_widgets/LinkmanSection.ui \
     item_widgets/LinkmanUserItem.ui \
-    item_widgets/LinkmanGroupItem.ui
+    item_widgets/LinkmanGroupItem.ui \
+    feature_widgets/PopupWidget.ui
 
 
 

--- a/css/login.css
+++ b/css/login.css
@@ -60,67 +60,23 @@
     background: url("://res/login/arrow-hover.png");
 }
 
-/*account input*/
-#comboBoxAccount:editable {
-    border: none;
+#pushButtonDropDown:checked{
+	background:url('://res/login/arrow-on.png');
 }
 
-#comboBoxAccount::drop-down {
-    image: url("://res/login/arrow.png");
+#pushButtonDropDown:unchecked{
+	background:url('://res/login/arrow.png');
 }
 
-/*delete，if not use #lineEditOuterInput,it can be enabled*/
-/*#comboBoxAccount:editable{
-    background: white;
-    padding:0px 16px 6px;
-    font-family: "微软雅黑";
-    font-size: 16px;
-    border:none;
-    border-bottom:1px solid rgb(229,229,229);
-    background:left top no-repeat url("://res/login/logo1.png") !important;
-}
 
-#comboBoxAccount::drop-down{
-    subcontrol-origin: padding;
-    subcontrol-position: top right;
-    width: 20px;
-    background: white;
-}
-
-#comboBoxAccount::down-arrow{
-    image:url("://res/login/arrow.png");
-}
-
-#comboBoxAccount::down-arrow:hover{
-    image:url("://res/login/arrow-hover.png");
-}
-
-#comboBoxAccount::down-arrow:on{
-    image:url("://res/login/arrow-on.png");
-}
-
-#comboBoxAccount:editable:focus,
-#comboBoxAccount:editable:on{
-    border-bottom:1px solid rgb(18,183,245);
-    background:left top no-repeat url("://res/login/logo2.png");
-}*/
-
-#comboBoxAccount QAbstractItemView {
-    outline: 0px;
-    height: 60px;
-    background-color: rgba(255, 255, 255, 0.9);
-    border: none;
-    selection-background-color: rgb(237, 237, 237);
-}
-
+/*
 QListView::item {
-    /*background-color: white;*/
     border: none;
 }
 
 QListView::item:hover {
     background-color: rgb(237, 237, 237);
-}
+}*/
 
 
 

--- a/feature_widgets/PopupWidget.cpp
+++ b/feature_widgets/PopupWidget.cpp
@@ -1,0 +1,75 @@
+#include "PopupWidget.h"
+#include "ui_PopupWidget.h"
+
+#include <QDebug>
+
+PopupWidget::PopupWidget(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::PopupWidget)
+{
+    ui->setupUi(this);
+    initResourceAndForm();
+    initSignalsAndSlots();
+}
+
+PopupWidget::~PopupWidget()
+{
+    delete ui;
+}
+
+
+void PopupWidget::initResourceAndForm()
+{
+    setWindowFlags(Qt::FramelessWindowHint | Qt::Popup | Qt::NoDropShadowWindowHint);
+}
+
+void PopupWidget::initSignalsAndSlots()
+{
+
+}
+
+
+void PopupWidget::closeEvent(QCloseEvent *event)
+{
+    emit sigHide();
+    QWidget::closeEvent(event);
+}
+
+void PopupWidget::hideEvent(QHideEvent *event)
+{
+    emit sigHide();
+    QWidget::hideEvent(event);
+}
+
+void PopupWidget::showWindow()
+{
+    qDebug() << "showWindow";
+    QWidget *parent = dynamic_cast<QWidget *>(this->parent()) ;
+    if(parent)
+    {
+//        if(ui->listWidget->count() < 1)
+//        {
+//            return;
+//        }
+        QRect geo = parent->geometry();
+        qDebug() << "parent geo: " << geo;
+        QPoint pos = parent->pos();
+        QSize size = parent->size();
+        QPoint globalPos = parent->mapToGlobal(pos);
+        qDebug() << "globalPos: " << globalPos;
+//        qDebug() << geo;
+        int height = ui->listWidget->count() * ItemHeight > ListMaxHeight
+                     ? ListMaxHeight
+                     : ui->listWidget->count() * ItemHeight;
+        this->setGeometry(globalPos.x() - 40, globalPos.y() - 30,
+                          size.width(), height);
+        qDebug() << "curr geo: " << this->geometry();
+        this->show();
+    }
+    else
+    {
+        qCritical() << "parent widget is null!";
+    }
+
+}
+

--- a/feature_widgets/PopupWidget.h
+++ b/feature_widgets/PopupWidget.h
@@ -1,0 +1,43 @@
+#ifndef POPUPWIDGET_H
+#define POPUPWIDGET_H
+
+#include <QWidget>
+
+namespace Ui {
+class PopupWidget;
+}
+
+class PopupWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PopupWidget(QWidget *parent = nullptr);
+    ~PopupWidget();
+
+
+    void showWindow();
+
+
+//    void addItem(const QString & content);
+signals:
+    void sigClick();
+    void sigHide();
+
+protected:
+    void closeEvent(QCloseEvent *event);
+    void hideEvent(QHideEvent *event);
+
+private:
+    void initResourceAndForm();
+    void initSignalsAndSlots();
+
+private:
+    Ui::PopupWidget *ui;
+
+
+    const static int ItemHeight = 50;
+    const static int ListMaxHeight = 200;
+};
+
+#endif // POPUPWIDGET_H

--- a/feature_widgets/PopupWidget.h
+++ b/feature_widgets/PopupWidget.h
@@ -1,7 +1,17 @@
+/**
+  * @file PopupWidget.h
+  * @brief 与LineEdit配合，组成一个ComboBox。
+  *     当前PopupWidget为ComboBox的下拉框
+  * @date 2021年3月23日17:21:13
+  * @author zsj
+  */
 #ifndef POPUPWIDGET_H
 #define POPUPWIDGET_H
 
 #include <QWidget>
+
+#include "main/LoginInfo.h"
+
 
 namespace Ui {
 class PopupWidget;
@@ -12,16 +22,30 @@ class PopupWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit PopupWidget(QWidget *parent = nullptr);
+    /**
+     * @brief PopupWidget
+     * @param parent 必须要有值。但不是为了设置父元素
+     * @note parent的值是为了定位下拉框显示的位置
+     */
+    explicit PopupWidget(QWidget *parent);
     ~PopupWidget();
 
 
+    /**
+     * @brief 显示窗口
+     * @note 不使用QWidget::show();
+     */
     void showWindow();
 
 
-//    void addItem(const QString & content);
+    /**
+     * @brief 下拉框添加元素
+     * @param info
+     */
+    void addItem(zsj::LoginInfo::ptr info);
+    void addItem(const zsj::LoginInfo & info);
 signals:
-    void sigClick();
+    void sigClick(zsj::LoginInfo::ptr info);
     void sigHide();
 
 protected:
@@ -32,12 +56,21 @@ private:
     void initResourceAndForm();
     void initSignalsAndSlots();
 
+    /**
+     * @brief 不能直接调用此函数
+     */
+    void show();
 private:
     Ui::PopupWidget *ui;
 
+    /// 下拉框属于哪个控件
+    QWidget * parent;
 
+    /// 下拉框item的高度
     const static int ItemHeight = 50;
-    const static int ListMaxHeight = 200;
+
+    /// 整个下拉框的最高高度
+    const static int ListMaxHeight = 180;
 };
 
 #endif // POPUPWIDGET_H

--- a/feature_widgets/PopupWidget.ui
+++ b/feature_widgets/PopupWidget.ui
@@ -48,10 +48,17 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="QListWidget" name="listWidget"/>
+    <widget class="MyListWidget" name="listWidget"/>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MyListWidget</class>
+   <extends>QListWidget</extends>
+   <header>customer_widgets/MyListWidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/feature_widgets/PopupWidget.ui
+++ b/feature_widgets/PopupWidget.ui
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PopupWidget</class>
+ <widget class="QWidget" name="PopupWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>250</width>
+    <height>200</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>250</width>
+    <height>50</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>250</width>
+    <height>200</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QListWidget" name="listWidget"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/item_widgets/ComboBoxItemWidget.cpp
+++ b/item_widgets/ComboBoxItemWidget.cpp
@@ -46,6 +46,11 @@ void ComboBoxItemWidget::initResourceAndForm()
     ui->labelAccount->setText(QString::number(info->getAccount()));
 }
 
+zsj::LoginInfo::ptr ComboBoxItemWidget::getInfo() const
+{
+    return info;
+}
+
 quint64 ComboBoxItemWidget::getAccountNum() const
 {
     return accountNum;

--- a/item_widgets/ComboBoxItemWidget.h
+++ b/item_widgets/ComboBoxItemWidget.h
@@ -49,6 +49,8 @@ public:
     quint64 getAccountNum() const;
     void setAccountNum(const quint64 &value);
 
+    zsj::LoginInfo::ptr getInfo() const;
+
 protected:
     /// @brief 鼠标松开时发送点击信号
     void mouseReleaseEvent(QMouseEvent *);


### PR DESCRIPTION
# 修复账号下拉框析构时崩溃的异常
1. 异常是因为设置Qt::Popup之后，窗口设置父窗口在析构时会出现段错误
2. 更改之前的账号输入框的实现逻辑。
3. 添加独立的widget来展示下拉框，独立的widget不设置父窗口